### PR TITLE
IsNullOrEmpty-Prüfung beim Hinzufügen von Sounds ergänzt

### DIFF
--- a/Ares.Editor/DragAndDrop.cs
+++ b/Ares.Editor/DragAndDrop.cs
@@ -148,7 +148,7 @@ namespace Ares.Editor
             String dir = item.ItemType == FileType.Music ? musicDirectory : soundDirectory;
             String path = System.IO.Path.Combine(dir, item.RelativePath);
             Un4seen.Bass.AddOn.Tags.TAG_INFO tag = Un4seen.Bass.AddOn.Tags.BassTags.BASS_TAG_GetFromFile(path, true, true);
-            if (tag != null)
+            if (!String.IsNullOrEmpty(tag?.title))
             {
                 element.Title = tag.title;
             }


### PR DESCRIPTION
Es kann vorkommen, dass zu einer Sound-Datei zwar Metadaten vorhanden sind, der Titel jedoch nicht gepflegt ist. In dem Fall wird beim Hinzufügen der Sound-Datei in ein Ares-Projekt ein Leerstring als Titel übernommen. 
Wird das Ares-Projekt nun gespeichert kann es später nicht wieder geöffnet werden, da der Titel ein Pflicht-Attribut ist und es beim Deserialisieren zu einer Exception kommt. 