### PR TITLE
Settings entry to disable file moving in the FileExplorer

### DIFF
--- a/Ares.Editor/Dialogs/ToolsPage.Designer.cs
+++ b/Ares.Editor/Dialogs/ToolsPage.Designer.cs
@@ -57,8 +57,11 @@ namespace Ares.Editor.Dialogs
             this.selectFileEditorButton = new System.Windows.Forms.Button();
             this.audioFileEditorBox = new System.Windows.Forms.TextBox();
             this.openFileDialog1 = new System.Windows.Forms.OpenFileDialog();
+            this.groupBox3 = new System.Windows.Forms.GroupBox();
+            this.allowFileMove = new System.Windows.Forms.CheckBox();
             this.groupBox2.SuspendLayout();
             this.groupBox1.SuspendLayout();
+            this.groupBox3.SuspendLayout();
             this.SuspendLayout();
             // 
             // groupBox2
@@ -121,10 +124,24 @@ namespace Ares.Editor.Dialogs
             // 
             resources.ApplyResources(this.openFileDialog1, "openFileDialog1");
             // 
+            // groupBox3
+            // 
+            resources.ApplyResources(this.groupBox3, "groupBox3");
+            this.groupBox3.Controls.Add(this.allowFileMove);
+            this.groupBox3.Name = "groupBox3";
+            this.groupBox3.TabStop = false;
+            // 
+            // allowFileMove
+            // 
+            resources.ApplyResources(this.allowFileMove, "allowFileMove");
+            this.allowFileMove.Name = "allowFileMove";
+            this.allowFileMove.UseVisualStyleBackColor = true;
+            // 
             // ToolsPage
             // 
             resources.ApplyResources(this, "$this");
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
+            this.Controls.Add(this.groupBox3);
             this.Controls.Add(this.groupBox2);
             this.Controls.Add(this.groupBox1);
             this.Name = "ToolsPage";
@@ -132,6 +149,8 @@ namespace Ares.Editor.Dialogs
             this.groupBox2.PerformLayout();
             this.groupBox1.ResumeLayout(false);
             this.groupBox1.PerformLayout();
+            this.groupBox3.ResumeLayout(false);
+            this.groupBox3.PerformLayout();
             this.ResumeLayout(false);
 
         }
@@ -147,5 +166,7 @@ namespace Ares.Editor.Dialogs
         private System.Windows.Forms.Button selectFileEditorButton;
         private System.Windows.Forms.TextBox audioFileEditorBox;
         private System.Windows.Forms.OpenFileDialog openFileDialog1;
+        private System.Windows.Forms.GroupBox groupBox3;
+        private System.Windows.Forms.CheckBox allowFileMove;
     }
 }

--- a/Ares.Editor/Dialogs/ToolsPage.cs
+++ b/Ares.Editor/Dialogs/ToolsPage.cs
@@ -35,12 +35,14 @@ namespace Ares.Editor.Dialogs
             InitializeComponent();
             audioFileEditorBox.Text = Ares.Settings.Settings.Instance.SoundFileEditor;
             musicPlayerBox.Text = Ares.Settings.Settings.Instance.ExternalMusicPlayer;
+            allowFileMove.Checked = Ares.Settings.Settings.Instance.AllowFileMove;
         }
 
         public void OnConfirm()
         {
             Ares.Settings.Settings.Instance.SoundFileEditor = audioFileEditorBox.Text;
             Ares.Settings.Settings.Instance.ExternalMusicPlayer = musicPlayerBox.Text;
+            Ares.Settings.Settings.Instance.AllowFileMove = allowFileMove.Checked;
         }
 
         private void selectFileEditorButton_Click(object sender, EventArgs e)

--- a/Ares.Editor/Dialogs/ToolsPage.resx
+++ b/Ares.Editor/Dialogs/ToolsPage.resx
@@ -112,26 +112,26 @@
     <value>2.0</value>
   </resheader>
   <resheader name="reader">
-    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <resheader name="writer">
-    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
-  <assembly alias="System.Windows.Forms" name="System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
+  <assembly alias="System.Windows.Forms" name="System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
   <data name="groupBox2.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
     <value>Top, Left, Right</value>
   </data>
   <data name="label2.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
     <value>NoControl</value>
   </data>
-  <assembly alias="System.Drawing" name="System.Drawing, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
+  <assembly alias="System.Drawing" name="System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
   <data name="label2.Location" type="System.Drawing.Point, System.Drawing">
     <value>6, 80</value>
   </data>
   <data name="label2.Size" type="System.Drawing.Size, System.Drawing">
     <value>335, 18</value>
   </data>
-  <assembly alias="mscorlib" name="mscorlib, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
+  <assembly alias="mscorlib" name="mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
   <data name="label2.TabIndex" type="System.Int32, mscorlib">
     <value>4</value>
   </data>
@@ -142,7 +142,7 @@
     <value>label2</value>
   </data>
   <data name="&gt;&gt;label2.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;label2.Parent" xml:space="preserve">
     <value>groupBox2</value>
@@ -169,7 +169,7 @@
     <value>label1</value>
   </data>
   <data name="&gt;&gt;label1.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;label1.Parent" xml:space="preserve">
     <value>groupBox2</value>
@@ -199,7 +199,7 @@
     <value>selectMusicPlayerButton</value>
   </data>
   <data name="&gt;&gt;selectMusicPlayerButton.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;selectMusicPlayerButton.Parent" xml:space="preserve">
     <value>groupBox2</value>
@@ -223,7 +223,7 @@
     <value>musicPlayerBox</value>
   </data>
   <data name="&gt;&gt;musicPlayerBox.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TextBox, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Windows.Forms.TextBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;musicPlayerBox.Parent" xml:space="preserve">
     <value>groupBox2</value>
@@ -247,13 +247,13 @@
     <value>groupBox2</value>
   </data>
   <data name="&gt;&gt;groupBox2.Type" xml:space="preserve">
-    <value>System.Windows.Forms.GroupBox, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Windows.Forms.GroupBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;groupBox2.Parent" xml:space="preserve">
     <value>$this</value>
   </data>
   <data name="&gt;&gt;groupBox2.ZOrder" xml:space="preserve">
-    <value>0</value>
+    <value>1</value>
   </data>
   <data name="groupBox1.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
     <value>Top, Left, Right</value>
@@ -280,7 +280,7 @@
     <value>selectFileEditorButton</value>
   </data>
   <data name="&gt;&gt;selectFileEditorButton.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;selectFileEditorButton.Parent" xml:space="preserve">
     <value>groupBox1</value>
@@ -304,7 +304,7 @@
     <value>audioFileEditorBox</value>
   </data>
   <data name="&gt;&gt;audioFileEditorBox.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TextBox, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Windows.Forms.TextBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;audioFileEditorBox.Parent" xml:space="preserve">
     <value>groupBox1</value>
@@ -328,39 +328,93 @@
     <value>groupBox1</value>
   </data>
   <data name="&gt;&gt;groupBox1.Type" xml:space="preserve">
-    <value>System.Windows.Forms.GroupBox, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Windows.Forms.GroupBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;groupBox1.Parent" xml:space="preserve">
     <value>$this</value>
   </data>
   <data name="&gt;&gt;groupBox1.ZOrder" xml:space="preserve">
-    <value>1</value>
+    <value>2</value>
   </data>
-  <metadata name="openFileDialog1.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+  <metadata name="openFileDialog1.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
     <value>17, 17</value>
   </metadata>
   <data name="openFileDialog1.Filter" xml:space="preserve">
     <value>Executables|*.exe|All Files|*.*</value>
   </data>
-  <metadata name="$this.Localizable" type="System.Boolean, mscorlib, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+  <data name="groupBox3.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
+    <value>Top, Left, Right</value>
+  </data>
+  <data name="allowFileMove.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="allowFileMove.Location" type="System.Drawing.Point, System.Drawing">
+    <value>9, 20</value>
+  </data>
+  <data name="allowFileMove.Size" type="System.Drawing.Size, System.Drawing">
+    <value>132, 17</value>
+  </data>
+  <data name="allowFileMove.TabIndex" type="System.Int32, mscorlib">
+    <value>0</value>
+  </data>
+  <data name="allowFileMove.Text" xml:space="preserve">
+    <value>Move files by dragging</value>
+  </data>
+  <data name="&gt;&gt;allowFileMove.Name" xml:space="preserve">
+    <value>allowFileMove</value>
+  </data>
+  <data name="&gt;&gt;allowFileMove.Type" xml:space="preserve">
+    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;allowFileMove.Parent" xml:space="preserve">
+    <value>groupBox3</value>
+  </data>
+  <data name="&gt;&gt;allowFileMove.ZOrder" xml:space="preserve">
+    <value>0</value>
+  </data>
+  <data name="groupBox3.Location" type="System.Drawing.Point, System.Drawing">
+    <value>3, 181</value>
+  </data>
+  <data name="groupBox3.Size" type="System.Drawing.Size, System.Drawing">
+    <value>381, 45</value>
+  </data>
+  <data name="groupBox3.TabIndex" type="System.Int32, mscorlib">
+    <value>8</value>
+  </data>
+  <data name="groupBox3.Text" xml:space="preserve">
+    <value>Drag and Drop</value>
+  </data>
+  <data name="&gt;&gt;groupBox3.Name" xml:space="preserve">
+    <value>groupBox3</value>
+  </data>
+  <data name="&gt;&gt;groupBox3.Type" xml:space="preserve">
+    <value>System.Windows.Forms.GroupBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;groupBox3.Parent" xml:space="preserve">
+    <value>$this</value>
+  </data>
+  <data name="&gt;&gt;groupBox3.ZOrder" xml:space="preserve">
+    <value>0</value>
+  </data>
+  <metadata name="$this.Localizable" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
     <value>True</value>
   </metadata>
   <data name="$this.AutoScaleDimensions" type="System.Drawing.SizeF, System.Drawing">
     <value>6, 13</value>
   </data>
   <data name="$this.Size" type="System.Drawing.Size, System.Drawing">
-    <value>387, 183</value>
+    <value>387, 240</value>
   </data>
   <data name="&gt;&gt;openFileDialog1.Name" xml:space="preserve">
     <value>openFileDialog1</value>
   </data>
   <data name="&gt;&gt;openFileDialog1.Type" xml:space="preserve">
-    <value>System.Windows.Forms.OpenFileDialog, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Windows.Forms.OpenFileDialog, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;$this.Name" xml:space="preserve">
     <value>ToolsPage</value>
   </data>
   <data name="&gt;&gt;$this.Type" xml:space="preserve">
-    <value>System.Windows.Forms.UserControl, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Windows.Forms.UserControl, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
 </root>

--- a/Ares.Editor/FileExplorer.cs
+++ b/Ares.Editor/FileExplorer.cs
@@ -284,7 +284,14 @@ namespace Ares.Editor
                 info.Source = FileSource.LocalFileSystem;
                 info.DraggedItems = items;
                 info.TagsFilter = m_TagsFilter;
-                DoDragDrop(info, DragDropEffects.Copy | DragDropEffects.Move);
+
+                DragDropEffects allowedEffects = DragDropEffects.Copy;
+                if (Settings.Settings.Instance.AllowFileMove)
+                {
+                    allowedEffects = DragDropEffects.Move;
+                }
+
+                DoDragDrop(info, allowedEffects);
                 m_InDrag = false;
             }
         }

--- a/Ares.Settings/Settings.cs
+++ b/Ares.Settings/Settings.cs
@@ -95,6 +95,8 @@ namespace Ares.Settings
 
         public int OutputDeviceIndex { get; set; }
 
+        public bool AllowFileMove { get; set; }
+
 		#if ANDROID
 		public String ProjectDirectory {get;set;}
 		public String PlayerName {get;set;}
@@ -112,6 +114,8 @@ namespace Ares.Settings
 		public String MusicDirectory { get { return Data.MusicDirectory; } private set { Data.MusicDirectory = value; } }
 		public String SoundDirectory { get { return Data.SoundDirectory; } private set { Data.SoundDirectory = value; } }
 		#endif
+
+        public bool AllowFileMove { get { return Data.AllowFileMove; } set { Data.AllowFileMove = value; } }
 
         public String LastDownloadLocation { get { return Data.LastDownloadLocation; } set { Data.LastDownloadLocation = value; } }
 
@@ -481,6 +485,7 @@ namespace Ares.Settings
             ShowTipOfTheDay = true;
             LastTipOfTheDay = -1;
             OutputDeviceIndex = -1;
+            AllowFileMove = true;
 			#if ANDROID
 			ProjectFolder = GetDefaultProjectDirectory();
 			PlayerName = "Android Player";
@@ -522,6 +527,7 @@ namespace Ares.Settings
             writer.WriteAttributeString("ShowKeys", ShowKeysInButtons ? "true" : "false");
             writer.WriteAttributeString("GlobalKeyHook", GlobalKeyHook ? "true" : "false");
             writer.WriteAttributeString("OutputDevice", OutputDeviceIndex.ToString(System.Globalization.CultureInfo.InvariantCulture));
+            writer.WriteAttributeString("AllowFileMove", AllowFileMove ? "true" : "false");
             writer.WriteEndElement();
             writer.WriteStartElement("Streaming");
             writer.WriteAttributeString("Active", UseStreaming ? "true" : "false");
@@ -660,6 +666,7 @@ namespace Ares.Settings
                     MessageFilterLevel = reader.GetIntegerAttribute("MessageFilterLevel");
                     ShowKeysInButtons = reader.GetBooleanAttributeOrDefault("ShowKeys", false);
                     GlobalKeyHook = reader.GetBooleanAttributeOrDefault("GlobalKeyHook", false);
+                    AllowFileMove = reader.GetBooleanAttributeOrDefault("AllowFileMove", true);
                     OutputDeviceIndex = reader.GetIntegerAttributeOrDefault("OutputDevice", -1);
                     if (reader.IsEmptyElement)
                         reader.Read();


### PR DESCRIPTION
(defaults to "true" - enable file moving)

Ich habe zwar schon länger nichts mehr an ARES gemacht, aber das Tool trotzdem weiterhin benutzt.
Dabei bin ich mehrfach in das Problem gelaufen, dass ich im FileExplorer versehentlich Dateien oder ganze Ordner verschoben haben. Da ich meine Musik-Sammlung separat verwalte, ist die "Verschieben"-Funktion für mich ohnehin irrelevant.

Um mir und anderen, die dieses Problem haben, eine Lösung zu bieten ohne für die restlichen ARES-Nutzer das gewohnte Verhalten zu verändern habe ich eine Einstellung hinzugefügt, mit der man das Verschieben von Dateien im FileExplorer deaktivieren kann.

Der Standard ist auf "Verschieben ist möglich", so dass sich für die Nutzer erst einmal nichts ändert.
Erst in dem Moment, wo man die Einstellung deaktiviert, ist das Verschieben von Dateien (bzw. Ordnern) im FileExplorer nicht mehr möglich.

Gruß
Martin